### PR TITLE
Add Bundler support for Ruby projects

### DIFF
--- a/src/solidlsp/language_servers/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph.py
@@ -67,35 +67,84 @@ class Solargraph(SolidLanguageServer):
         except FileNotFoundError as e:
             raise RuntimeError("Ruby is not installed. Please install Ruby before continuing.") from e
 
-        # Check if solargraph is installed
+        # Check for Bundler project (Gemfile exists)
+        gemfile_path = os.path.join(repository_root_path, "Gemfile")
+        gemfile_lock_path = os.path.join(repository_root_path, "Gemfile.lock")
+        is_bundler_project = os.path.exists(gemfile_path)
+
+        if is_bundler_project:
+            logger.log("Detected Bundler project (Gemfile found)", logging.INFO)
+
+            # Check if bundle command is available
+            bundle_path = shutil.which("bundle")
+            if not bundle_path:
+                # Try common bundle executables
+                for bundle_cmd in ["bin/bundle", "bundle"]:
+                    bundle_full_path = (
+                        os.path.join(repository_root_path, bundle_cmd) if bundle_cmd.startswith("bin/") else shutil.which(bundle_cmd)
+                    )
+                    if bundle_full_path and os.path.exists(bundle_full_path):
+                        bundle_path = bundle_full_path if bundle_cmd.startswith("bin/") else bundle_cmd
+                        break
+
+            if not bundle_path:
+                raise RuntimeError("Bundler project detected but 'bundle' command not found. Please install Bundler.")
+
+            # Check if solargraph is in Gemfile.lock
+            solargraph_in_bundle = False
+            if os.path.exists(gemfile_lock_path):
+                try:
+                    with open(gemfile_lock_path) as f:
+                        content = f.read()
+                        solargraph_in_bundle = "solargraph" in content.lower()
+                except Exception as e:
+                    logger.log(f"Warning: Could not read Gemfile.lock: {e}", logging.WARNING)
+
+            if solargraph_in_bundle:
+                logger.log("Found solargraph in Gemfile.lock", logging.INFO)
+                return f"{bundle_path} exec solargraph"
+            else:
+                logger.log(
+                    "solargraph not found in Gemfile.lock. Please add 'gem \"solargraph\"' to your Gemfile and run 'bundle install'",
+                    logging.WARNING,
+                )
+                # Fall through to global installation check
+
+        # Check if solargraph is installed globally
         # First, try to find solargraph in PATH (includes asdf shims)
         solargraph_path = shutil.which("solargraph")
         if solargraph_path:
             logger.log(f"Found solargraph at: {solargraph_path}", logging.INFO)
             return solargraph_path
 
-        # Fallback to gem exec
-        runtime_dependencies = [
-            {
-                "url": "https://rubygems.org/downloads/solargraph-0.51.1.gem",
-                "installCommand": "gem install solargraph -v 0.51.1",
-                "binaryName": "solargraph",
-                "archiveType": "gem",
-            }
-        ]
+        # Fallback to gem exec (for non-Bundler projects or when global solargraph not found)
+        if not is_bundler_project:
+            runtime_dependencies = [
+                {
+                    "url": "https://rubygems.org/downloads/solargraph-0.51.1.gem",
+                    "installCommand": "gem install solargraph -v 0.51.1",
+                    "binaryName": "solargraph",
+                    "archiveType": "gem",
+                }
+            ]
 
-        dependency = runtime_dependencies[0]
-        try:
-            result = subprocess.run(
-                ["gem", "list", "^solargraph$", "-i"], check=False, capture_output=True, text=True, cwd=repository_root_path
+            dependency = runtime_dependencies[0]
+            try:
+                result = subprocess.run(
+                    ["gem", "list", "^solargraph$", "-i"], check=False, capture_output=True, text=True, cwd=repository_root_path
+                )
+                if result.stdout.strip() == "false":
+                    logger.log("Installing Solargraph...", logging.INFO)
+                    subprocess.run(dependency["installCommand"].split(), check=True, capture_output=True, cwd=repository_root_path)
+
+                return "gem exec solargraph"
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(f"Failed to check or install Solargraph. {e.stderr}") from e
+        else:
+            raise RuntimeError(
+                "This appears to be a Bundler project, but solargraph is not available. "
+                "Please add 'gem \"solargraph\"' to your Gemfile and run 'bundle install'."
             )
-            if result.stdout.strip() == "false":
-                logger.log("Installing Solargraph...", logging.INFO)
-                subprocess.run(dependency["installCommand"].split(), check=True, capture_output=True, cwd=repository_root_path)
-
-            return "gem exec solargraph"
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"Failed to check or install Solargraph. {e.stderr}") from e
 
     @staticmethod
     def _get_initialize_params(repository_absolute_path: str) -> InitializeParams:


### PR DESCRIPTION
## Summary

This PR adds comprehensive Bundler support to the Solargraph Ruby language server implementation, addressing permission issues with rbenv and system-managed Ruby installations.

### Changes Made

- **Bundler project detection**: Automatically detects Ruby projects using Bundler by checking for `Gemfile` existence
- **Smart bundle command resolution**: Supports both `bin/bundle` and `bundle` commands commonly used in Ruby projects  
- **Gemfile.lock parsing**: Checks if `solargraph` is available in the project's bundle before attempting to use it
- **Intelligent fallback**: Falls back to global solargraph installation when not available in bundle
- **Enhanced error messages**: Provides clear guidance when solargraph is missing from Bundler projects

### Problem Solved

Previously, Serena would fail on Ruby projects configured with `bundle config --local path vendor/bundle` due to permission errors when attempting to install gems globally. This commonly occurs with:
- rbenv-managed Ruby installations
- Projects using vendor/bundle for dependency isolation
- Corporate environments with restricted gem installation permissions

### Test Plan

- [x] Code formatting with `uv run poe format`
- [x] Type checking with `uv run poe type-check` 
- [x] Maintains backward compatibility with non-Bundler Ruby projects
- [x] Handles missing bundle command gracefully
- [x] Provides appropriate error messages for misconfigured projects

### Usage

For Ruby projects using Bundler, simply add solargraph to your Gemfile:

```ruby
gem 'solargraph', group: :development
```

Then run `bundle install` or `bin/bundle install`. Serena will automatically detect and use the bundled version.

🤖 Generated with [Claude Code](https://claude.ai/code)