### PR TITLE
Add debugging for Ruby symbol search timeout issues

### DIFF
--- a/src/solidlsp/language_servers/solargraph.py
+++ b/src/solidlsp/language_servers/solargraph.py
@@ -36,11 +36,16 @@ class Solargraph(SolidLanguageServer):
         Use LanguageServer.create() instead.
         """
         solargraph_executable_path = self._setup_runtime_dependencies(logger, config, repository_root_path)
+
+        # Temporarily enable debug logging for Solargraph to diagnose timeout issues
+        debug_env = {"SOLARGRAPH_LOG_LEVEL": "debug"}
+        logger.log("Enabling SOLARGRAPH_LOG_LEVEL=debug for timeout debugging", logging.INFO)
+
         super().__init__(
             config,
             logger,
             repository_root_path,
-            ProcessLaunchInfo(cmd=f"{solargraph_executable_path} stdio", cwd=repository_root_path),
+            ProcessLaunchInfo(cmd=f"{solargraph_executable_path} stdio", cwd=repository_root_path, env=debug_env),
             "ruby",
             solidlsp_settings,
         )
@@ -50,7 +55,9 @@ class Solargraph(SolidLanguageServer):
         self.resolve_main_method_available = threading.Event()
 
         # Set timeout for Solargraph requests - Bundler environments may need more time
-        self.set_request_timeout(120.0)  # 120 seconds for initialization and requests
+        self.set_request_timeout(
+            120.0
+        )  # 120 seconds for initialization and requests  # 120 seconds for initialization and requests  # 120 seconds for initialization and requests
 
     @override
     def is_ignored_dirname(self, dirname: str) -> bool:


### PR DESCRIPTION
## Summary
- Add comprehensive debugging logs to diagnose timeout issues when searching for Ruby symbols like `CleanupOldDurationalRecommendSchedulesWorker`
- Enable automatic `SOLARGRAPH_LOG_LEVEL=debug` for Solargraph language server
- Add timing and progress tracking throughout the symbol search pipeline

## Changes Made

### Solargraph Debug Logging (`src/solidlsp/language_servers/solargraph.py`)
- Automatically enables `SOLARGRAPH_LOG_LEVEL=debug` via ProcessLaunchInfo environment variables
- Provides detailed Solargraph internal logging for timeout diagnosis

### LSP Request Debugging (`src/solidlsp/ls_handler.py`)
- Request timing with warnings for requests taking >10 seconds
- Language server process health checks on timeout
- Detailed timeout error reporting with elapsed times and process status

### Symbol Search Debugging (`src/serena/symbol.py`)
- Symbol search start/completion logging with timing
- Progress tracking every 100 symbol roots for large projects
- Performance warnings for searches taking >30 seconds
- Comprehensive error reporting with timing information

## Problem Context
Ruby projects with complex symbol names (like `CleanupOldDurationalRecommendSchedulesWorker`) are experiencing timeout issues during `find_symbol` operations. This enhancement will help identify whether timeouts occur during:

1. Solargraph initialization and workspace analysis
2. LSP communication bottlenecks
3. Large symbol tree traversal
4. Language server process failures

## Test Plan
- [ ] Test with Ruby projects containing long class names
- [ ] Verify debug logs appear when timeout occurs
- [ ] Confirm performance impact is minimal for normal operations
- [ ] Validate that environment variables are properly set for Solargraph process

## Notes
This is a temporary debugging measure to gather diagnostic information. The enhanced logging can be removed or made configurable once the root cause is identified and resolved.

🤖 Generated with [Claude Code](https://claude.ai/code)