### PR TITLE
fix: remove call to deleted _get_rbenv_bundle_command method

### DIFF
--- a/src/solidlsp/language_servers/ruby_lsp.py
+++ b/src/solidlsp/language_servers/ruby_lsp.py
@@ -176,17 +176,16 @@ class RubyLsp(SolidLanguageServer):
             logger.log("Detected Bundler project (Gemfile found)", logging.INFO)
 
             # Check if bundle command is available using Windows-compatible search
-            bundle_cmd = RubyLsp._get_rbenv_bundle_command(repository_root_path)
             bundle_path = RubyLsp._find_executable_with_extensions(bundle_cmd[0] if len(bundle_cmd) == 1 else "bundle")
             if not bundle_path:
                 # Try common bundle executables
-                for bundle_cmd in ["bin/bundle", "bundle"]:
-                    if bundle_cmd.startswith("bin/"):
-                        bundle_full_path = os.path.join(repository_root_path, bundle_cmd)
+                for bundle_executable in ["bin/bundle", "bundle"]:
+                    if bundle_executable.startswith("bin/"):
+                        bundle_full_path = os.path.join(repository_root_path, bundle_executable)
                     else:
-                        bundle_full_path = RubyLsp._find_executable_with_extensions(bundle_cmd)
+                        bundle_full_path = RubyLsp._find_executable_with_extensions(bundle_executable)
                     if bundle_full_path and os.path.exists(bundle_full_path):
-                        bundle_path = bundle_full_path if bundle_cmd.startswith("bin/") else bundle_cmd
+                        bundle_path = bundle_full_path if bundle_executable.startswith("bin/") else bundle_executable
                         break
 
             if not bundle_path:


### PR DESCRIPTION
Fixes AttributeError when running Serena on Ruby projects.

Issue:
- Commit 6b077d1 removed _get_rbenv_bundle_command() as part of rbenv refactoring, but line 179 still called this non-existent method
- This caused "AttributeError: type object 'RubyLsp' has no attribute '_get_rbenv_bundle_command'" when initializing Ruby language server

Changes:
- Remove the call to deleted _get_rbenv_bundle_command() method
- Use the bundle_cmd variable that was already set earlier in the function
- Rename loop variable from bundle_cmd to bundle_executable to avoid variable shadowing and type conflicts (bundle_cmd is list[str], loop needs str)

Testing:
- All 31 Ruby tests pass
- No linting or formatting errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)